### PR TITLE
Add Support for Excluding Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mgit -e "repo,repo2" -run "go get -u"
 mgit -e "repo,repo2" -tags
 ```
 
-The `-e` flag lets you specify a repository (or comma separated list of repositories) that mgit will skip when tagging or running a command
+The `-e` flag lets you specify a repository (or comma separated list of repositories) that mgit will skip when tagging or running a command.
 
 ### Setting working directory
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ mgit -run "npm update"
 
 The `-run` flag lets you specify a command to run in every git repository. The command will be executed in parallel (one async routine per repository).
 
+### Exclude a Repository
+
+```shell
+mgit -e "repo,repo2" -run "go get -u"
+```
+
+```shell
+mgit -e "repo,repo2" -tags
+```
+
+The `-e` flag lets you specify a repository (or comma separated list of repositories) that mgit will skip when tagging or running a command
+
 ### Setting working directory
 
 ```shell

--- a/mgit.go
+++ b/mgit.go
@@ -8,11 +8,13 @@ import (
 )
 
 var (
-	tags         bool
-	dry          bool
-	tag          string
-	root         string
-	shellCommand string
+	tags          bool
+	dry           bool
+	tag           string
+	root          string
+	shellCommand  string
+	excludedRepos string
+	skipped       map[string]bool
 )
 
 func init() {
@@ -21,6 +23,7 @@ func init() {
 	flag.StringVar(&tag, "tag", "", "Specifies the tag increment for every outdated git repository (syntax: +0.0.1 to increase the SemVer minor)")
 	flag.StringVar(&root, "root", ".", "Specifies the directory to search for git repositories")
 	flag.StringVar(&shellCommand, "run", "", "Specifies a shell command to execute in every git repository")
+	flag.StringVar(&excludedRepos, "e", "", "Comma Separated List of Repos to Exclude")
 	flag.Parse()
 }
 
@@ -44,6 +47,14 @@ func main() {
 	if dry && tag == "" {
 		fmt.Println("Dry run is only possible when -tag option is specified")
 		return
+	}
+
+	if excludedRepos != "" {
+		skipped = make(map[string]bool)
+		excluded := strings.Split(excludedRepos, ",")
+		for _, repo := range excluded {
+			skipped[repo] = true
+		}
 	}
 
 	// Process repositories in parallel

--- a/walk.go
+++ b/walk.go
@@ -27,7 +27,7 @@ func walk(file string, info os.FileInfo, err error) error {
 	name := info.Name()
 
 	if name != "." && strings.HasPrefix(name, ".") {
-		if name == ".git" {
+		if name == ".git" && !isSkipped(file) {
 			repositoryPath := strings.TrimSuffix(file, ".git")
 			repositoryPath = path.Clean(repositoryPath)
 
@@ -170,4 +170,14 @@ func getLatestTag(dir string) string {
 
 	out = bytes.TrimSpace(out)
 	return string(out)
+}
+
+func isSkipped(repo string) bool {
+	repositoryPath := strings.TrimSuffix(repo, ".git")
+	repositoryPath = path.Clean(repositoryPath)
+	_, file := filepath.Split(repositoryPath)
+	if skipped[file] {
+		return true
+	}
+	return false
 }

--- a/walk.go
+++ b/walk.go
@@ -176,8 +176,6 @@ func isSkipped(repo string) bool {
 	repositoryPath := strings.TrimSuffix(repo, ".git")
 	repositoryPath = path.Clean(repositoryPath)
 	_, file := filepath.Split(repositoryPath)
-	if skipped[file] {
-		return true
-	}
-	return false
+
+	return skipped[file]
 }


### PR DESCRIPTION
Adds #1 

Sometimes it is nice to exclude repositories from an mgit execution,
this gives the tool the ability to specify a comma separated list of
repos to skip.

Let me know what you think! 